### PR TITLE
Nudge probe-rs into trying the next probe-driver

### DIFF
--- a/probe-rs/src/probe.rs
+++ b/probe-rs/src/probe.rs
@@ -619,7 +619,7 @@ pub trait ProbeFactory: std::any::Any + std::fmt::Display + std::fmt::Debug + Sy
         &self,
         _selector: &TcpDebugProbeSelector,
     ) -> Result<Box<dyn DebugProbe>, DebugProbeError> {
-        Err(DebugProbeError::TargetNotFound)
+        Err(DebugProbeError::ProbeCouldNotBeCreated(ProbeCreationError::NotFound))
     }
 
     /// Returns a list of all available debug probes of the current type.


### PR DESCRIPTION
i.e. moving onto our `cmsisdap` driver

See `probe-rs/src/probe/list.rs` - `AllProbesLister::open()`:

https://github.com/chrisprice/probe-rs/blob/e69545269d7f6baa06b848bb9a76f72caaa04c16/probe-rs/src/probe/list.rs#L92-L100